### PR TITLE
Update section_1_Initial_Setup.yaml

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -1099,7 +1099,7 @@
 # AppArmor provides Mandatory Access Controls.
 - name: 1.7.1.1 Ensure AppArmor is installed
   apt:
-    name: ["apparmor"]
+    name: ["apparmor", "apparmor-utils]
     state: present
   tags:
     - section1


### PR DESCRIPTION
Cyberwatch detects we do not pass rule 1.7.1.1 since it checks whether apparmor AND apparmor-utils are installed on the target host. This MR solves this by adding apparmor-utils to the installed packages array.