### PR TITLE
Update all_mounts_facts.yaml

### DIFF
--- a/tasks/all_mounts_facts.yaml
+++ b/tasks/all_mounts_facts.yaml
@@ -7,5 +7,3 @@
   changed_when: false
   check_mode: false
   register: all_mounts
-  tags: 
-    - always


### PR DESCRIPTION
It seems that the "always" tag messes up the playbook whenever this role is used in any play but hardening.