### PR TITLE
SECU-954 Fix CIS rule 6.2.14

### DIFF
--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -602,12 +602,13 @@
   block:
     - name: 6.2.14 Ensure no users have .rhosts files - list
       script: 6_2_14.sh
-      changed_when: output_6_2_14.stdout | trim | length > 0
+      changed_when: output_6_2_14.stdout | default([]) | trim | length > 0
       register: output_6_2_14
       check_mode: no
-    - name: 6.2.11 Ensure no users have .rhosts files - print output
+      
+    - name: 6.2.14 Ensure no users have .rhosts files - print output
       debug:
-        msg: "{{ output_6_2_14.stdout_lines }}"
+        msg: "{{ output_6_2_14.stdout_lines | default([]) }}"
   tags:
     - section6
     - level_1_server


### PR DESCRIPTION
The tasks default to an empty array whenever the 6_2_14.sh script does not return anything.