### PR TITLE
SECU-954 Fix CIS rule 4.1.1.4

### DIFF
--- a/tasks/section_4_Logging_and_Auditing.yaml
+++ b/tasks/section_4_Logging_and_Auditing.yaml
@@ -55,7 +55,7 @@
   replace:
     dest: /etc/default/grub
     regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit_backlog_limit)\"[^\"]*)(\".*)'
-    replace: '\1 audit_backlog_limit={{ grub_backlog_limit }}\2'
+    replace: '\1 audit_backlog_limit={{ grub_backlog_limit | default(8192) }}\2'
   tags:
     - section4
     - level_2_server


### PR DESCRIPTION
audit_backlog_limit was missing a default value. 8192 was chosen since it is the value already set on several servers.