### PR TITLE
SECU-954 Fix CIS rule 4.1.1.3

### DIFF
--- a/tasks/section_4_Logging_and_Auditing.yaml
+++ b/tasks/section_4_Logging_and_Auditing.yaml
@@ -40,6 +40,8 @@
     dest: /etc/default/grub
     regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit)\"[^\"]*)(\".*)'
     replace: '\1 audit=1\2'
+    state: present
+    create: true
   tags:
     - section4
     - level_2_server


### PR DESCRIPTION
This rule was allegedly missing a default value. Since it was not clear what was missing, I thought that the /etc/default/grub presence could be checked just in case (even though it might be totally unnecessary).