### PR TITLE
SECU-954 Fix CIS rule 3.5.2.5

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -592,7 +592,7 @@
     rule: "{{ item.rule }}"
     port: "{{ item.port }}"
     proto: "{{ item.proto }}"
-  with_items: "{{ list_of_rules_to_allow }}"
+  with_items: "{{ list_of_rules_to_allow | default([]) }}"
   tags:
     - section3
     - level_1_server


### PR DESCRIPTION
list_of_rules_to_allow should default to an empty array to prevent a loop execution failure (in case item does not exist).