### PR TITLE
SECU-954 Fix CIS rule 3.5.4.2.4

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -1033,7 +1033,7 @@
     match: state
     ctstate: NEW
     jump: ACCEPT
-  with_items: "{{ list_of_rules_to_allow }}"
+  with_items: "{{ list_of_rules_to_allow | default([]) }}"
   tags:
     - section3
     - level_1_server


### PR DESCRIPTION
list_of_rules_to_allow should default to an empty array in case it is null or undefined.