### PR TITLE
SECU-954 Fix CIS rule 1.6.2

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -1025,6 +1025,7 @@
     state: present
     reload: true
     sysctl_set: true
+    create: true
   tags:
     - section1
     - level_1_server


### PR DESCRIPTION
This rule is allegedly missing a default value. Since it is unclear what is missing, I chose to add create: true for the /etc/sysctl.d/CIS-sysctl.conf file so that it is created if absent.