### PR TITLE
Remove create parameter on rule 1.6.2

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -1034,7 +1034,6 @@
     state: present
     reload: true
     sysctl_set: true
-    create: true
   tags:
     - section1
     - level_1_server


### PR DESCRIPTION
The hardening has failed because of this parameter which apparently does not exist for the sysctl command.