### PR TITLE
Fix CIS rule 4.1.1.3

### DIFF
--- a/tasks/section_4_Logging_and_Auditing.yaml
+++ b/tasks/section_4_Logging_and_Auditing.yaml
@@ -40,8 +40,6 @@
     dest: /etc/default/grub
     regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit)\"[^\"]*)(\".*)'
     replace: '\1 audit=1\2'
-    state: present
-    create: true
   tags:
     - section4
     - level_2_server


### PR DESCRIPTION
The create parameter does not exist on the replace module.