### PR TITLE
fix: ansible 2.14 compatibility

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -204,7 +204,7 @@
       register: tmp_mount_result
       ignore_errors: yes
       changed_when: false
-      
+
     - name: Check if /tmp is a separate partition
       assert:
         that: tmp_mount_result | length > 0
@@ -225,8 +225,6 @@
     - name: 1.1.3 Ensure nodev option set on /tmp partition - get info
       shell: |
         mount | grep -E '\s/tmp\s' | grep -v nodev 2>/dev/null
-      args:
-        warn: false
       ignore_errors: yes
       register: output_1_1_3
       changed_when: output_1_1_3.stdout_lines | length > 0
@@ -234,8 +232,6 @@
     - name: 1.1.3 Ensure nodev option set on /tmp partition - get fstab opts
       shell: |
         mount | grep -E '\s/tmp\s' | sed 's/.*(\(.*\)).*/\1/' 2>/dev/null
-      args:
-        warn: false
       register: output_1_1_3_opts
       changed_when: false
       check_mode: no
@@ -266,8 +262,6 @@
     - name: 1.1.4 Ensure nosuid option set on /tmp partition - get info
       shell: |
         mount | grep -E '\s/tmp\s' | grep -v nosuid 2>/dev/null
-      args:
-        warn: false
       ignore_errors: yes
       register: output_1_1_4
       changed_when: output_1_1_4.stdout_lines | length > 0
@@ -275,8 +269,6 @@
     - name: 1.1.4 Ensure nosuid option set on /tmp partition - get fstab opts
       shell: |
         mount | grep -E '\s/tmp\s' | sed 's/.*(\(.*\)).*/\1/' 2>/dev/null
-      args:
-        warn: false
       register: output_1_1_4_opts
       changed_when: false
       check_mode: no
@@ -307,8 +299,6 @@
     - name: 1.1.5 Ensure noexec option set on /tmp partition - get info
       shell: |
         mount | grep -E '\s/tmp\s' | grep -v noexec 2>/dev/null
-      args:
-        warn: false
       ignore_errors: yes
       register: output_1_1_5
       changed_when: output_1_1_5.stdout_lines | length > 0
@@ -316,8 +306,6 @@
     - name: 1.1.5 Ensure noexec option set on /tmp partition - get fstab opts
       shell: |
         mount | grep -E '\s/tmp\s' | sed 's/.*(\(.*\)).*/\1/' 2>/dev/null
-      args:
-        warn: false
       register: output_1_1_5_opts
       changed_when: false
       check_mode: no
@@ -384,8 +372,6 @@
     - name: 1.1.8 Ensure nodev option set on /var/tmp partition - get info
       shell: |
         mount | grep -E '\s/var/tmp\s' | grep -v nodev 2>/dev/null
-      args:
-        warn: false
       ignore_errors: yes
       register: output_1_1_8
       changed_when: output_1_1_8.stdout_lines | length > 0
@@ -393,8 +379,6 @@
     - name: 1.1.8 Ensure nodev option set on /var/tmp partition - get fstab opts
       shell: |
         mount | grep -E '\s/var/tmp\s' | sed 's/.*(\(.*\)).*/\1/' 2>/dev/null
-      args:
-        warn: false
       register: output_1_1_8_opts
       changed_when: false
       check_mode: no
@@ -425,8 +409,6 @@
     - name: 1.1.9 Ensure nosuid option set on /var/tmp partition - get info
       shell: |
         mount | grep -E '\s/var/tmp\s' | grep -v nosuid 2>/dev/null
-      args:
-        warn: false
       ignore_errors: yes
       register: output_1_1_9
       changed_when: output_1_1_9.stdout_lines | length > 0
@@ -434,8 +416,6 @@
     - name: 1.1.9 Ensure nosuid option set on /var/tmp partition - get fstab opts
       shell: |
         mount | grep -E '\s/var/tmp\s' | sed 's/.*(\(.*\)).*/\1/' 2>/dev/null
-      args:
-        warn: false
       register: output_1_1_9_opts
       changed_when: false
       check_mode: no
@@ -466,8 +446,6 @@
     - name: 1.1.10 Ensure noexec option set on /var/tmp partition - get info
       shell: |
         mount | grep -E '\s/var/tmp\s' | grep -v noexec 2>/dev/null
-      args:
-        warn: false
       ignore_errors: yes
       register: output_1_1_10
       changed_when: output_1_1_10.stdout_lines | length > 0
@@ -475,8 +453,6 @@
     - name: 1.1.10 Ensure noexec option set on /var/tmp partition - get fstab opts
       shell: |
         mount | grep -E '\s/var/tmp\s' | sed 's/.*(\(.*\)).*/\1/' 2>/dev/null
-      args:
-        warn: false
       register: output_1_1_10_opts
       changed_when: false
       check_mode: no
@@ -1265,4 +1241,3 @@
     - manual_setup
     - not-scored
   when: debian10cis_rules_1_8_2
-


### PR DESCRIPTION
As of ansible 2.14, the warn parameter shell module is no longer supported. 